### PR TITLE
adds Landmark and Script features

### DIFF
--- a/roguelite.py
+++ b/roguelite.py
@@ -19,40 +19,55 @@ class Tile:
         self.blocked = blocked
  
         #by default, if a tile is blocked, it also blocks sight
-        if block_sight is None: block_sight = blocked
-        self.block_sight = block_sight
-		
-class Combat:
-	#a class containing logic necessary to run during the combat state
-		
+        if block_sight is None:
+            block_sight = blocked
+            self.block_sight = block_sight
+        
+#class Combat:
+    #a class containing logic necessary to run during the combat state
+        
 class Script:
-	#a script/ or story (basically an event) is a class that contains logic necessary for running a Landmark in the text adventure state,
-	#or a landmark and its encounter in text adventure state
-		
-class Encounter:
-	#encounter has to be just data
-	#
-	#encounter has a collection of objects which can be carried between landmarks to make the text events more variable
-	#
-	#encounter will likely need a subset of it's objects to be defined as combatants, since these objects will trigger the combat state
- 
- class Landmark(Object):
-	#a location on the map that you can enter
-	def __init__(self, x, y, char, color, name, objects, event)
-		Object.__init__(self, x, y, char, color)
-		self.name = name
-		self.objects = objects
-		self.event = event
-		
-	def update(self):
-		for object in objects
-			if Object.collide(self, object)
-				#run event if available
-				self.runEvent(self)
-								
-					
-	
-	
+    def __init__(self, name=None, data=None, scripts=None):
+        self.name = name
+        self.data = data
+        self.scripts = scripts
+        
+    def __str__(self):
+        return str(self.name)
+    
+        
+
+    def getChoice(self):
+        self.choice = raw_input("=>")
+        if not self.scripts.keys():
+            return False
+        if self.choice in self.scripts.keys():
+            return True
+        return False
+
+    def run(self):
+        while True:
+            print
+            print(self.data)
+            print
+            if self.scripts:
+                for scr in self.scripts.values():
+                    print(scr.name)
+            if not self.getChoice():
+                break
+            if self.scripts:
+                self = self.scripts.get(self.choice)
+        #a script/ or story (basically an event) is a class that contains logic necessary for running a Landmark in the text adventure state,
+    #or a landmark and its encounter in text adventure state
+        
+#class Encounter:
+    #encounter has to be just data
+    #
+    #encounter has a collection of objects which can be carried between landmarks to make the text events more variable
+    #
+    #encounter will likely need a subset of it's objects to be defined as combatants, since these objects will trigger the combat state
+    
+    
 class Object:
     #this is a generic object: the player, a monster, an item, the stairs...
     #it's always represented by a character on screen.
@@ -68,10 +83,10 @@ class Object:
             self.x += dx
             self.y += dy
  
-	def update(self):
-		for object in objects
-			if collide(self, object)
-			######Do something
+    #def update(self):
+     #   for object in objects:
+      #      if collide(self, object):
+                ######Do something
  
     def draw(self):
         #set the color and then draw the character that represents this object at its position
@@ -82,10 +97,29 @@ class Object:
         #erase the character that represents this object
         libtcod.console_put_char(con, self.x, self.y, ' ', libtcod.BKGND_NONE)
  
-	def collide(self, object)
-		if self.y == object.y and self.x == object.x:
-			return True
-		else return False
+    def collide(self, object):
+        if self.y == object.y and self.x == object.x:
+            return True
+        else:
+            return False
+
+ 
+class Landmark(Object):
+     
+    #a location on the map that you can enter
+    def __init__(self, x, y, char, color, name, objects, event):
+        Object.__init__(self, x, y, char, color)
+        self.name = name
+        self.objects = objects
+        self.event = event
+        
+    def update(self):
+        for obj in self.objects:
+            if Object.collide(self, obj):
+                #run event if available
+                self.event.run()
+                                
+              
  
 def make_map():
     global map
@@ -158,12 +192,17 @@ con = libtcod.console_new(SCREEN_WIDTH, SCREEN_HEIGHT)
  
 #create object representing the player
 player = Object(SCREEN_WIDTH/2, SCREEN_HEIGHT/2, '@', libtcod.white)
- 
+
+holeInMound = Script("a hole", "You reach inside the hole, you can't reach the end of the hole.")
+discoverMound = Script("Atop the Mound", "on the plain, a two foot high vantage point can seem significant, until you view the hawk overhead.", {holeInMound.name:holeInMound})
+holeInMound.scripts = {discoverMound.name:discoverMound}
+mound = Landmark(SCREEN_WIDTH/2 + 10, SCREEN_HEIGHT/2 + 1, '^', libtcod.grey, "Mound", [player], discoverMound)
+
 #create an NPC
 npc = Object(SCREEN_WIDTH/2 - 5, SCREEN_HEIGHT/2, '@', libtcod.yellow)
  
 #the list of objects with those two
-objects = [npc, player]
+objects = [npc, player, mound]
  
 #generate map (at this point it's not drawn to the screen)
 make_map()
@@ -173,16 +212,16 @@ while not libtcod.console_is_window_closed():
  
     #render the screen
     render_all()
- 
     libtcod.console_flush()
  
     #erase all objects at their old locations, before they move
     for object in objects:
         object.clear()
  
+    objects[2].update()
     #handle keys and exit game if needed
     exit = handle_keys()
     if exit:
         break
-		
+        
 raw_input("PRESS ENTER")


### PR DESCRIPTION
encounter still isn't implemented. it may not ever be implemented, depends on what we need.
right now the way it works is you initialize a script with its dictionary of attached scripts

in the case of holeInMound when i say holeInMound.scripts = {discoverMound.name:discoverMound}

its setting the scripts dictionary to have only one key/value pair, the key is the script.name, and the value is the script itself

also youl notice since holeInMound is defined before discoverMound is defined, then you can't define its scripts in holeInMound's constructor, so you have to define its scripts after discoverMound has already been defined

this way the map looks like this:

holeInMound <-----> discoverMound

also to exit a text portion just enter an invalid answer to where you want to go